### PR TITLE
Rename plus fixing the concept of gossip

### DIFF
--- a/examples/network.rs
+++ b/examples/network.rs
@@ -240,12 +240,10 @@ impl TestNode {
     fn tick(&mut self) {
         if !self.is_in_round {
             self.is_in_round = true;
-
-            let (peer_id, msgs_to_send) = unwrap!(self.node.next_round());
-            if let Some(message_stream) = self.peers.get_mut(&peer_id) {
-                // Buffer the messages to be sent.
-                for msg in msgs_to_send {
-                    message_stream.buffer(&msg);
+            if let Ok((peer_id, Some(gossip_to_send))) = self.node.next_round() {
+                if let Some(message_stream) = self.peers.get_mut(&peer_id) {
+                    // Buffer the gossip to be sent.
+                    message_stream.buffer(&gossip_to_send);
                 }
             }
         }
@@ -260,9 +258,9 @@ impl TestNode {
             loop {
                 match message_stream.poll() {
                     Ok(Async::Ready(Some(message))) => {
-                        let msgs_to_send = self.node.receive_rumor(peer_id, &message);
+                        let msgs_to_send = self.node.receive_gossip(peer_id, &message);
                         // Buffer the messages to be sent back.
-                        for msg in msgs_to_send {
+                        if let Some(msg) = msgs_to_send {
                             has_response = true;
                             message_stream.buffer(&msg);
                         }
@@ -319,7 +317,7 @@ impl Future for TestNode {
             .node
             .rumors()
             .into_iter()
-            .map(|serialised| unwrap!(deserialize::<String>(&serialised)))
+            .map(|rumor| unwrap!(deserialize::<String>(&rumor.content.0)))
             .collect_vec();
         let id = self.id();
         unwrap!(self.stats_sender.unbounded_send((id, rumors, stats)));

--- a/src/id.rs
+++ b/src/id.rs
@@ -12,7 +12,7 @@ use std::convert::From;
 use std::fmt::{self, Debug, Formatter};
 
 /// The ID of a node - equivalent to its public key.
-#[derive(Clone, Copy, Ord, PartialOrd, Eq, PartialEq, Hash)]
+#[derive(Clone, Copy, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct Id(pub [u8; PUBLIC_KEY_LENGTH]);
 
 impl From<PublicKey> for Id {

--- a/src/rumor_state.rs
+++ b/src/rumor_state.rs
@@ -12,7 +12,7 @@ use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, BTreeSet};
 
 /// This represents the state of a single rumor from this node's perspective.
-#[derive(Debug)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum RumorState {
     /// Exponential-growth phase.
     B {
@@ -35,6 +35,12 @@ pub enum RumorState {
     },
     /// Propagation complete.
     D,
+}
+
+impl Default for RumorState {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl RumorState {


### PR DESCRIPTION
Now with this we send 1 gossip with multiple rumors in it.
Previously we sent a `vec` with multiple "gossips" that had "msg",
but these were really rumors, and then we had to create a Pull
response only for the first item in the `vec` because the semantics
was really that a pull is created per `Gossip`, which is a `vec` of rumors.